### PR TITLE
Fix moes thermostat local temp negative values

### DIFF
--- a/converters/fromZigbee.js
+++ b/converters/fromZigbee.js
@@ -2740,7 +2740,7 @@ const converters = {
             case tuya.dataPoints.moesMinTemp:
                 return {min_temperature: value};
             case tuya.dataPoints.moesLocalTemp:
-                temperature = value & 1<<15 ? value - (1<<16) +1 : value
+                temperature = value & 1<<15 ? value - (1<<16) +1 : value;
                 return {local_temperature: parseFloat((temperature / 10).toFixed(1))};
             case tuya.dataPoints.moesTempCalibration:
                 temperature = value;

--- a/converters/fromZigbee.js
+++ b/converters/fromZigbee.js
@@ -1595,6 +1595,7 @@ const converters = {
         cluster: 'ssIasZone',
         type: 'commandStatusChangeNotification',
         convert: (model, msg, publish, options, meta) => {
+            if (hasAlreadyProcessedMessage(msg)) return;
             const lookup = {1: 'pressed'};
             const zoneStatus = msg.data.zonestatus;
             return {

--- a/converters/fromZigbee.js
+++ b/converters/fromZigbee.js
@@ -2740,7 +2740,8 @@ const converters = {
             case tuya.dataPoints.moesMinTemp:
                 return {min_temperature: value};
             case tuya.dataPoints.moesLocalTemp:
-                return {local_temperature: parseFloat((value / 10).toFixed(1))};
+                temperature = value & 1<<15 ? value - (1<<16) +1 : value
+                return {local_temperature: parseFloat((temperature / 10).toFixed(1))};
             case tuya.dataPoints.moesTempCalibration:
                 temperature = value;
                 // for negative values produce complimentary hex (equivalent to negative values)

--- a/converters/fromZigbee.js
+++ b/converters/fromZigbee.js
@@ -4361,7 +4361,10 @@ const converters = {
         type: 'commandOnWithTimedOff',
         convert: (model, msg, publish, options, meta) => {
             if (msg.data.ctrlbits === 1) return;
-            const timeout = msg.data.ontime / 10;
+
+            const timeout = options && options.hasOwnProperty('occupancy_timeout') ?
+                options.occupancy_timeout : msg.data.ontime / 10;
+
             // Stop existing timer because motion is detected and set a new one.
             clearTimeout(globalStore.getValue(msg.endpoint, 'timer'));
 

--- a/converters/fromZigbee.js
+++ b/converters/fromZigbee.js
@@ -5031,7 +5031,7 @@ const converters = {
         convert: (model, msg, publish, options, meta) => {
             const buttonLookup = {1: 'on', 2: 'up', 3: 'down', 4: 'off'};
             const button = buttonLookup[msg.data['button']];
-            const typeLookup = {0: 'press', 1: 'hold', 2: 'release', 3: 'release'};
+            const typeLookup = {0: 'press', 1: 'hold', 2: 'press_release', 3: 'hold_release'};
             const type = typeLookup[msg.data['type']];
             const payload = {action: `${button}_${type}`};
 

--- a/devices.js
+++ b/devices.js
@@ -1180,7 +1180,8 @@ const devices = [
 
     // TuYa
     {
-        fingerprint: [{modelID: 'TS011F', manufacturerName: '_TZ3000_rk2yzt0u'}, {modelID: 'TS0001', manufacturerName: '_TZ3000_o4cjetlm'}, {manufacturerName: '_TZ3000_o4cjetlm'}],
+        fingerprint: [{modelID: 'TS011F', manufacturerName: '_TZ3000_rk2yzt0u'},
+            {modelID: 'TS0001', manufacturerName: '_TZ3000_o4cjetlm'}, {manufacturerName: '_TZ3000_o4cjetlm'}],
         model: 'ZN231392',
         vendor: 'TuYa',
         description: 'Smart water/gas valve',

--- a/devices.js
+++ b/devices.js
@@ -1180,7 +1180,7 @@ const devices = [
 
     // TuYa
     {
-        fingerprint: [{modelID: 'TS011F', manufacturerName: '_TZ3000_rk2yzt0u'}, {manufacturerName: '_TZ3000_o4cjetlm'}],
+        fingerprint: [{modelID: 'TS011F', manufacturerName: '_TZ3000_rk2yzt0u'}, {modelID: 'TS0001', manufacturerName: '_TZ3000_o4cjetlm'}, {manufacturerName: '_TZ3000_o4cjetlm'}],
         model: 'ZN231392',
         vendor: 'TuYa',
         description: 'Smart water/gas valve',

--- a/devices.js
+++ b/devices.js
@@ -2473,6 +2473,15 @@ const devices = [
         onEvent: ikea.bulbOnEvent,
     },
     {
+        zigbeeModel: ['SILVERGLANS IP44 LED driver'],
+        model: 'ICPSHC24-30-IL44-1',
+        vendor: 'IKEA',
+        description: 'SILVERGLANS IP44 LED driver for wireless control (30 watt)',
+        extend: preset.light_onoff_brightness(),
+        ota: ota.tradfri,
+        onEvent: ikea.bulbOnEvent,
+    },
+    {
         zigbeeModel: ['FLOALT panel WS 30x30'],
         model: 'L1527',
         vendor: 'IKEA',

--- a/devices.js
+++ b/devices.js
@@ -1180,6 +1180,13 @@ const devices = [
 
     // TuYa
     {
+        fingerprint: [{modelID: 'TS011F', manufacturerName: '_TZ3000_rk2yzt0u'}, {manufacturerName: '_TZ3000_o4cjetlm'}],
+        model: 'ZN231392',
+        vendor: 'TuYa',
+        description: 'Smart water/gas valve',
+        extend: preset.switch(),
+    },
+    {
         fingerprint: [{modelID: 'TS0505B', manufacturerName: '_TZ3000_qqjaziws'}],
         model: 'TS0505B',
         vendor: 'TuYa',
@@ -2263,13 +2270,6 @@ const devices = [
         configure: async (device, coordinatorEndpoint, logger) => {
             await reporting.bind(device.getEndpoint(1), coordinatorEndpoint, ['genOnOff']);
         },
-    },
-    {
-        fingerprint: [{modelID: 'TS011F', manufacturerName: '_TZ3000_rk2yzt0u'}],
-        model: 'TS011F_valve',
-        vendor: 'Lonsonho',
-        description: 'Smart water/gas valve (upgrade version)',
-        extend: preset.switch(),
     },
 
     // IKEA

--- a/devices.js
+++ b/devices.js
@@ -1487,11 +1487,9 @@ const devices = [
         toZigbee: [],
         meta: {configureKey: 1},
         configure: async (device, coordinatorEndpoint, logger) => {
-            try {
-                const endpoint = device.getEndpoint(1);
-                await reporting.bind(endpoint, coordinatorEndpoint, ['genPowerCfg']);
-                await reporting.batteryPercentageRemaining(endpoint);
-            } catch (error) {/* Fails for some: https://github.com/Koenkk/zigbee2mqtt/issues/6313 */}
+            const endpoint = device.getEndpoint(1);
+            await reporting.bind(endpoint, coordinatorEndpoint, ['genPowerCfg']);
+            await reporting.batteryPercentageRemaining(endpoint);
         },
     },
     {

--- a/devices.js
+++ b/devices.js
@@ -1496,7 +1496,9 @@ const devices = [
         configure: async (device, coordinatorEndpoint, logger) => {
             const endpoint = device.getEndpoint(1);
             await reporting.bind(endpoint, coordinatorEndpoint, ['genPowerCfg']);
-            await reporting.batteryPercentageRemaining(endpoint);
+            try {
+                await reporting.batteryPercentageRemaining(endpoint);
+            } catch (error) {/* Fails for some: https://github.com/Koenkk/zigbee2mqtt/issues/6313 */}
         },
     },
     {

--- a/devices.js
+++ b/devices.js
@@ -13507,9 +13507,10 @@ const devices = [
         model: 'TERNCY-DC01',
         vendor: 'TERNCY',
         description: 'Temperature & contact sensor ',
-        fromZigbee: [fz.terncy_temperature, fz.terncy_contact],
+        fromZigbee: [fz.terncy_temperature, fz.terncy_contact, fz.battery],
         toZigbee: [],
-        exposes: [e.temperature(), e.contact()],
+        exposes: [e.temperature(), e.contact(), e.battery()],
+        meta: {battery: {dontDividePercentage: true}},
     },
     {
         zigbeeModel: ['TERNCY-PP01'],

--- a/devices.js
+++ b/devices.js
@@ -14306,6 +14306,19 @@ const devices = [
         onEvent: tuya.onEventSetLocalTime,
     },
     {
+        fingerprint: [{modelID: 'TS0601', manufacturerName: '_TZE200_amp6tsvy'}],
+        model: 'ZTS-EU',
+        vendor: 'Moes',
+        description: 'Wall touch light switch (1 gang)',
+        exposes: [e.switch().setAccess('state', ea.STATE_SET)],
+        fromZigbee: [fz.tuya_switch_1, fz.tuya_switch_2],
+        toZigbee: [tz.tuya_switch_state],
+        meta: {configureKey: 1},
+        configure: async (device, coordinatorEndpoint, logger) => {
+            await reporting.bind(device.getEndpoint(1), coordinatorEndpoint, ['genOnOff']);
+        },
+    },
+    {
         fingerprint: [{modelID: 'GbxAXL2\u0000', manufacturerName: '_TYST11_KGbxAXL2'},
             {modelID: 'uhszj9s\u0000', manufacturerName: '_TYST11_zuhszj9s'},
             {modelID: '88teujp\u0000', manufacturerName: '_TYST11_c88teujp'},

--- a/devices.js
+++ b/devices.js
@@ -1487,9 +1487,11 @@ const devices = [
         toZigbee: [],
         meta: {configureKey: 1},
         configure: async (device, coordinatorEndpoint, logger) => {
-            const endpoint = device.getEndpoint(1);
-            await reporting.bind(endpoint, coordinatorEndpoint, ['genPowerCfg']);
-            await reporting.batteryPercentageRemaining(endpoint);
+            try {
+                const endpoint = device.getEndpoint(1);
+                await reporting.bind(endpoint, coordinatorEndpoint, ['genPowerCfg']);
+                await reporting.batteryPercentageRemaining(endpoint);
+            } catch (error) {/* Fails for some: https://github.com/Koenkk/zigbee2mqtt/issues/6313 */}
         },
     },
     {

--- a/devices.js
+++ b/devices.js
@@ -1510,6 +1510,12 @@ const devices = [
         exposes: [e.battery(), e.action(['1_single', '1_double', '1_hold', '2_single', '2_double', '2_hold'])],
         fromZigbee: [fz.tuya_on_off_action, fz.battery],
         toZigbee: [],
+        meta: {configureKey: 1},
+        configure: async (device, coordinatorEndpoint, logger) => {
+            const endpoint = device.getEndpoint(1);
+            await reporting.bind(endpoint, coordinatorEndpoint, ['genPowerCfg']);
+            await reporting.batteryPercentageRemaining(endpoint);
+        },
     },
     {
         zigbeeModel: ['TS0043'],

--- a/devices.js
+++ b/devices.js
@@ -3507,6 +3507,15 @@ const devices = [
         ota: ota.zigbeeOTA,
     },
     {
+        zigbeeModel: ['LCW002'],
+        model: '4090230P9',
+        vendor: 'Philips',
+        description: 'Hue Liane',
+        meta: {turnsOffAtBrightness1: true},
+        extend: preset.hue.light_onoff_brightness_colortemp_color(),
+        ota: ota.zigbeeOTA,
+    },
+    {
         zigbeeModel: ['LTC001'],
         model: '3261030P7',
         vendor: 'Philips',

--- a/devices.js
+++ b/devices.js
@@ -1587,6 +1587,7 @@ const devices = [
             {modelID: 'TS0601', manufacturerName: '_TZE200_wmcdj3aq'},
             {modelID: 'TS0601', manufacturerName: '_TZE200_cowvfni3'},
             {modelID: 'TS0601', manufacturerName: '_TZE200_rddyvrci'},
+            {modelID: 'zo2pocs\u0000', manufacturerName: '_TYST11_fzo2pocs'},
             // Roller blinds:
             {modelID: 'TS0601', manufacturerName: '_TZE200_sbordckq'},
             {modelID: 'TS0601', manufacturerName: '_TZE200_fctwhugx'},

--- a/npm-shrinkwrap.json
+++ b/npm-shrinkwrap.json
@@ -1,6 +1,6 @@
 {
   "name": "zigbee-herdsman-converters",
-  "version": "14.0.60",
+  "version": "14.0.61",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/npm-shrinkwrap.json
+++ b/npm-shrinkwrap.json
@@ -1,6 +1,6 @@
 {
   "name": "zigbee-herdsman-converters",
-  "version": "14.0.59",
+  "version": "14.0.60",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "zigbee-herdsman-converters",
-  "version": "14.0.59",
+  "version": "14.0.60",
   "description": "Collection of device converters to be used with zigbee-herdsman",
   "main": "index.js",
   "files": [

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "zigbee-herdsman-converters",
-  "version": "14.0.60",
+  "version": "14.0.61",
   "description": "Collection of device converters to be used with zigbee-herdsman",
   "main": "index.js",
   "files": [


### PR DESCRIPTION
Local temperature comes as a 16bit signed integer with the last digit as a fraction. When chunks are saved into JS's integer sign bit is lost. As a result, for example, at -2.9 local temperature zigbee converter outputs 6550.6 .
This change fixes this problem. I am not sure what is the logic behind "case tuya.dataPoints.moesTempCalibration:" is, it seems to be doing something close but then it has to be -4095 and be compared to 2048.